### PR TITLE
Fix: Export validator from "medusa-extender" lib

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ export {
 	Middleware,
 	Migration,
 	Router,
-	Validator
+	Validator,
 } from './decorators';
 
 export { MonitoringOptions } from './modules/monitoring';

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ export {
 	Middleware,
 	Migration,
 	Router,
+	Validator
 } from './decorators';
 
 export { MonitoringOptions } from './modules/monitoring';


### PR DESCRIPTION
Validator is not being exported from the main index file.

So this doesn't work - import { Validator } from 'medusa-extender' ,
instead I had to import it from import { Validator } from 'medusa-extender/dist/decorators';

This PR would fix the issue.