### PR TITLE
feat: add optional param to init with already loaded config

### DIFF
--- a/src/Medusa.ts
+++ b/src/Medusa.ts
@@ -42,7 +42,7 @@ export class Medusa {
 		this.#express = express;
 		this.#rootDir = rootDir;
 
-		if(config) {
+		if (config) {
 			this.#config = { configModule: config };
 		}
 	}
@@ -51,9 +51,11 @@ export class Medusa {
 	 * @param modules The modules to load into medusa
 	 */
 	public async load(modules: Type[]): Promise<MedusaContainer> {
-		const { configModule } = this.#config || getConfigFile(this.#rootDir, 'medusa-config') as {
-			configModule: ConfigModule;
-		};
+		const { configModule } =
+			this.#config ||
+			(getConfigFile(this.#rootDir, 'medusa-config') as {
+				configModule: ConfigModule;
+			});
 
 		const moduleComponentsOptions = await modulesLoader(modules, configModule);
 

--- a/src/Medusa.ts
+++ b/src/Medusa.ts
@@ -17,6 +17,7 @@ import {
 	validatorsLoader,
 } from './loaders';
 import { loadMonitoringModule, MonitoringOptions } from './modules/monitoring';
+import { ConfigModule } from './modules/multi-tenancy/types';
 
 // Use to fix MiddlewareService typings
 declare global {
@@ -31,24 +32,27 @@ const logger = Logger.contextualize('Medusa');
 export class Medusa {
 	readonly #express: Express;
 	readonly #rootDir: string;
+	readonly #config: { configModule: ConfigModule };
 
 	/**
 	 * @param rootDir Directory where the `medusa-config` is located
 	 * @param express Express instance
 	 */
-	constructor(rootDir: string, express: Express) {
+	constructor(rootDir: string, express: Express, config?: ConfigModule) {
 		this.#express = express;
 		this.#rootDir = rootDir;
+
+		if(config) {
+			this.#config = { configModule: config };
+		}
 	}
 
 	/**
 	 * @param modules The modules to load into medusa
 	 */
 	public async load(modules: Type[]): Promise<MedusaContainer> {
-		const { configModule } = getConfigFile(this.#rootDir, 'medusa-config') as {
-			configModule: {
-				monitoring: MonitoringOptions;
-			};
+		const { configModule } = this.#config || getConfigFile(this.#rootDir, 'medusa-config') as {
+			configModule: ConfigModule;
 		};
 
 		const moduleComponentsOptions = await modulesLoader(modules, configModule);

--- a/src/modules/multi-tenancy/types.ts
+++ b/src/modules/multi-tenancy/types.ts
@@ -5,7 +5,7 @@ import { MonitoringOptions } from '../monitoring';
 export type ConfigModule = Record<string, unknown> & {
 	multi_tenancy?: MultiTenancyOptions;
 	projectConfig: { database_logging?: LoggerOptions };
-	monitoring?: MonitoringOptions;			
+	monitoring?: MonitoringOptions;
 };
 
 export interface MultiTenancyOptions {

--- a/src/modules/multi-tenancy/types.ts
+++ b/src/modules/multi-tenancy/types.ts
@@ -1,9 +1,11 @@
 import { LoggerOptions } from 'typeorm';
 import { MedusaRequest } from '../../core';
+import { MonitoringOptions } from '../monitoring';
 
 export type ConfigModule = Record<string, unknown> & {
 	multi_tenancy?: MultiTenancyOptions;
 	projectConfig: { database_logging?: LoggerOptions };
+	monitoring?: MonitoringOptions;			
 };
 
 export interface MultiTenancyOptions {


### PR DESCRIPTION
so since medusa itself is stripping off some props from the config, we can give here the possibility to init with an already loaded config.

reason for this is, if you wanna seed with an custom config and need during the seed custom props, youll not get them.