### PR TITLE
feat(cli): Allow to specify tenants on which to apply the migrate command

### DIFF
--- a/src/cli/commands/migrate.ts
+++ b/src/cli/commands/migrate.ts
@@ -22,6 +22,8 @@ type ConfigModule = {
 
 const logger = Logger.contextualize('Migrate command', 'MEDEX-CLI');
 
+type Options = { run: boolean; revert: boolean; show: boolean; tenants: string };
+
 /**
  * Run the migrations using the medusa-config.js config.
  * @param run
@@ -29,7 +31,7 @@ const logger = Logger.contextualize('Migrate command', 'MEDEX-CLI');
  * @param show
  * @param tenants
  */
-export async function migrate({ run, revert, show, tenants }): Promise<void> {
+export async function migrate({ run, revert, show, tenants }: Options): Promise<void> {
 	const { configModule } = getConfigFile(process.cwd(), `medusa-config`) as { configModule: ConfigModule };
 	const configMigrationsDirs =
 		configModule.projectConfig.cli_migration_dirs ?? configModule.projectConfig.cliMigrationsDirs;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -13,18 +13,20 @@ program.name('medex').description('Medusa extender CLI').version('0.8.1');
 program
 	.command('migrate')
 	.alias('m')
-	.description(
-		"Migrate all migrations from ['src/**/*.migration.js', 'src/**/migrations/*.js', 'dist/**/*.migration.js', 'dist/**/migrations/*.js']"
-	)
+	.description('Migrate all migrations found in the specified directories in the configuration')
 	.option('-r, --run', 'Run migrations up method')
 	.option('-u, --revert', 'Revert the last migrations')
 	.option('-s, --show', 'Show all applied and non applied migrations')
-	.action(async (options, program) => {
+	.argument(
+		'<tenant_codes>',
+		'Specify on which tenant to run the command for. It can be composed of a mix of string or regexp that are comma separated (e.g "tenant1,/specialTenant.*/")'
+	)
+	.action(async (tenant_codes, options, program) => {
 		console.time(green('Migration command'));
 		if (Object.values(options).every((value) => !value)) {
 			return program.showHelpAfterError(true).error('You must specify one of the options.');
 		}
-		await migrate(options);
+		await migrate({ ...options, tenants: tenant_codes });
 		console.timeEnd(green('Migration command'));
 	});
 
@@ -46,6 +48,7 @@ program
 	)
 	.argument('<name>', 'specify the name of the component(s) to create')
 	.action((name: string, options: GenerateCommandOptions, program: Command) => {
+		console.time(green('Generate command'));
 		const { path, ...componentOptions } = options;
 		if (Object.values(componentOptions).every((value) => !value)) {
 			return program
@@ -53,6 +56,7 @@ program
 				.error(`You must specify one of the options.${path ? ' --path only is not sufficient.' : ''}`);
 		}
 		generateComponent(name, options);
+		console.timeEnd(green('Generate command'));
 	});
 
 program
@@ -62,7 +66,9 @@ program
 		'Update your existing medusa project to include the necessary configuration to use the medusa-extender package'
 	)
 	.action(async () => {
+		console.time(green('Init command'));
 		await init();
+		console.timeEnd(green('Init command'));
 	});
 
 program.parse();

--- a/src/cli/tests/cli.spec.ts
+++ b/src/cli/tests/cli.spec.ts
@@ -25,7 +25,7 @@ describe('CLI', () => {
 		expect(error.code).toBe(1);
 		expect(normalizeString(stderr)).toBe(
 			normalizeString(`
-            Usage: medex [options] [command]
+			Usage: medex [options] [command]
 
 			Medusa extender CLI
 			
@@ -34,12 +34,10 @@ describe('CLI', () => {
 				-h, --help                  display help for command
 			
 			Commands:
-				migrate|m [options]         Migrate all migrations from ['src/**/*.migration.js',
-									        'src/**/migrations/*.js', 'dist/**/*.migration.js',
-									        'dist/**/migrations/*.js']
-				generate|g [options] <name> Generate a new component
-			    init|-i                     Update your existing medusa project to include the necessary configuration to use the medusa-extender package
-				help [command]              display help for command
+				migrate|m [options] <tenant_codes>        Migrate all migrations found in the specified directories in the configuration
+				generate|g [options] <name> 							Generate a new component
+			  init|-i                     							Update your existing medusa project to include the necessary configuration to use the medusa-extender package
+				help [command]              							display help for command
         `)
 		);
 	});
@@ -80,21 +78,24 @@ describe('CLI', () => {
 	});
 
 	it('should failed on migrate command with missing options', async () => {
-		const { error, stderr } = await cli(['migrate'], '.');
+		const { error, stderr } = await cli(['migrate "tenant1"'], '.');
 		expect(error.code).toBe(1);
 		expect(normalizeString(stderr)).toBe(
 			normalizeString(`
-            You must specify one of the options.
+				You must specify one of the options.
 
-			Usage: medex migrate|m [options]
-			
-			Migrate all migrations from ['src/**/*.migration.js', 'src/**/migrations/*.js', 'dist/**/*.migration.js', 'dist/**/migrations/*.js']
-			
-			Options:
-			  -r, --run     Run migrations up method
-			  -u, --revert  Revert the last migrations
-			  -s, --show    Show all applied and non applied migrations
-			  -h, --help    display help for command
+				Usage: medex migrate|m [options] <tenant_codes>
+				
+				Migrate all migrations found in the specified directories in the configuration
+				
+				Arguments:
+					tenant_codes  Specify on which tenant to run the command for. It can be composed of a mix of string or regexp that are comma separated (e.g "tenant1,/specialTenant.*/")
+				
+				Options:
+					-r, --run     Run migrations up method
+					-u, --revert  Revert the last migrations
+					-s, --show    Show all applied and non applied migrations
+					-h, --help    display help for command
         `)
 		);
 	});

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -67,3 +67,15 @@ export function lowerCaseFirst(str: string): string {
 export function upperCaseFirst(str: string): string {
 	return str.charAt(0).toUpperCase() + str.slice(1);
 }
+
+export function buildRegexpIfValid(str: string): RegExp | undefined {
+	try {
+		const m = str.match(/^([/~@;%#'])(.*?)\1([gimsuy]*)$/);
+		if (m) {
+			const regexp = new RegExp(m[2], m[3]);
+			return regexp;
+		}
+	} catch (e) {}
+
+	return;
+}


### PR DESCRIPTION
**What**
The migration cli command should be able to be applied on the specified tenants and if not specified then it would be applied on the main DB only