### PR TITLE
fix(cli): Update watch script

### DIFF
--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -17,7 +17,6 @@ export async function init(): Promise<void> {
 	await loadPackages(logger, [
 		{ name: 'typescript', version: '4.5.5', isDevDependency: true },
 		{ name: 'nodemon', version: '2.0.15', isDevDependency: true },
-		{ name: 'ts-node', version: '10.7.0', isDevDependency: true },
 	]);
 
 	await updatePackageJson();
@@ -44,7 +43,7 @@ async function updatePackageJson(): Promise<void> {
 		...(packageJson.scripts ?? {}),
 		build: 'rm -rf dist && ./node_modules/.bin/tsc -p tsconfig.json',
 		start: 'npm run build && NODE_ENV=development node ./dist/main.js',
-		'start:watch': "nodemon --watch './src/**/*.ts' --exec 'ts-node' ./src/main.ts",
+		'start:watch': "nodemon --watch './src/**/*.ts' --exec 'npm run build && npm start'",
 		'start:prod': 'npm run build && NODE_ENV=production node dist/main',
 	};
 	writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 4));

--- a/src/cli/tests/commands/init.spec.ts
+++ b/src/cli/tests/commands/init.spec.ts
@@ -54,7 +54,6 @@ describe('Init command', () => {
 		expect(loadPackagesMock).toHaveBeenCalledWith(expect.anything(), [
 			{ name: 'typescript', version: '4.5.5', isDevDependency: true },
 			{ name: 'nodemon', version: '2.0.15', isDevDependency: true },
-			{ name: 'ts-node', version: '10.7.0', isDevDependency: true },
 		]);
 
 		const packageJson = await import(resolve(fakeProjectPath, 'package.json'));
@@ -63,7 +62,7 @@ describe('Init command', () => {
 			expect.objectContaining({
 				build: 'rm -rf dist && ./node_modules/.bin/tsc -p tsconfig.json',
 				start: 'npm run build && NODE_ENV=development node ./dist/main.js',
-				'start:watch': "nodemon --watch './src/**/*.ts' --exec 'ts-node' ./src/main.ts",
+				'start:watch': "nodemon --watch './src/**/*.ts' --exec 'npm run build && npm start'",
 				'start:prod': 'npm run build && NODE_ENV=production node dist/main',
 			})
 		);


### PR DESCRIPTION
From the issue mentioned here  https://github.com/TypeStrong/ts-node/issues/897 the watch script cannot use ts-node