### PR TITLE
Fix: Documentation

### DIFF
--- a/documentation/02-api-documentation.md
+++ b/documentation/02-api-documentation.md
@@ -607,7 +607,7 @@ export default class ProductSubscriber implements EntitySubscriberInterface<Prod
     }
     
     public async beforeInsert(event: InsertEvent<Product>): Promise<InsertEvent<Product>> {
-        return eventEmitter.emitAsync<InsertEvent<Product>>(OnMedusaEntityEvent.Before.InsertEvent(Product), {
+        return await eventEmitter.emitAsync<InsertEvent<Product>>(OnMedusaEntityEvent.Before.InsertEvent(Product), {
             event,
             transactionalEntityManager: event.manager,
         });

--- a/documentation/02-api-documentation.md
+++ b/documentation/02-api-documentation.md
@@ -745,4 +745,3 @@ export class User extends Utils.Omit(MedusaUser, ['role']) {
     )
     role: UserRolesExtended;
 }
-```


### PR DESCRIPTION
Discrepancy between Docs and Starter example. Docs is missing `await` in the `eventEmitter`.

See https://github.com/adrien2p/medusa-extender/blob/main/starters/server/src/modules/user/user.subscriber.ts#L20