### PR TITLE
Fix Documentation

### DIFF
--- a/starters/server/src/modules/user/user.subscriber.ts
+++ b/starters/server/src/modules/user/user.subscriber.ts
@@ -17,7 +17,7 @@ export default class UserSubscriber implements EntitySubscriberInterface<User> {
 	 * @param event Event to pass to the event handler
 	 */
 	public async beforeInsert(event: InsertEvent<User>): Promise<void> {
-		return await eventEmitter.emitAsync(OnMedusaEntityEvent.Before.InsertEvent(User), {
+		return eventEmitter.emitAsync(OnMedusaEntityEvent.Before.InsertEvent(User), {
 			event,
 			transactionalEntityManager: event.manager,
 		});


### PR DESCRIPTION
Discrepancy between Docs and Starter example. Docs does not have `await` in the `eventEmitter`.

See https://github.com/juanzgc/medusa-extender/blob/main/documentation/02-api-documentation.md?plain=1#L610