### PR TITLE
FIX: modules loader

### DIFF
--- a/src/core/componentMap.ts
+++ b/src/core/componentMap.ts
@@ -1,6 +1,18 @@
 import { GetInjectableOptions, InjectableComponentTypes } from './types';
 
 export class ComponentMap extends Map<InjectableComponentTypes, GetInjectableOptions> {
+	constructor(entries?: readonly (readonly [InjectableComponentTypes, GetInjectableOptions])[] | null) {
+		if (!entries || entries.length === 1) {
+			super(entries);
+			return;
+		}
+
+		const mergedEntries = new Map();
+		for (const [entryComponentType, entryOptions] of entries) {
+			mergedEntries.set(entryComponentType, [...(mergedEntries.get(entryComponentType) ?? []), ...entryOptions]);
+		}
+		super(mergedEntries.entries());
+	}
 	get<TComponentType extends InjectableComponentTypes>(key: TComponentType): GetInjectableOptions<TComponentType> {
 		return super.get(key) as GetInjectableOptions<TComponentType>;
 	}

--- a/src/loaders/tests/modules.loader.spec.ts
+++ b/src/loaders/tests/modules.loader.spec.ts
@@ -18,6 +18,16 @@ class MyDynamicModule implements MedusaDynamicModule {
 @Service()
 class TestService2 {}
 
+@Module({ imports: [TestService2] })
+class MyModule2 {}
+
+@Module()
+class MyDynamicModule2 implements MedusaDynamicModule {
+	async forRoot(): Promise<ModuleInjectionOptions> {
+		return { imports: [TestService2] };
+	}
+}
+
 @Module()
 class MyDynamicModuleWithSubModule implements MedusaDynamicModule {
 	async forRoot(): Promise<ModuleInjectionOptions> {
@@ -46,5 +56,31 @@ describe('Modules loader', () => {
 		expect(services.length).toBe(2);
 		expect(new services[0].metatype()).toBeInstanceOf(TestService);
 		expect(new services[1].metatype()).toBeInstanceOf(TestService2);
+	});
+
+	it('should load multiple decorated modules', async () => {
+		const componentsMap = await modulesLoader([MyModule, MyModule2], {});
+		const services = componentsMap.get('service');
+		expect(services.length).toBe(2);
+		expect(new services[0].metatype()).toBeInstanceOf(TestService);
+		expect(new services[1].metatype()).toBeInstanceOf(TestService2);
+	});
+
+	it('should load multiple dynamic modules', async () => {
+		const componentsMap = await modulesLoader([MyDynamicModule, MyDynamicModule2], {});
+		const services = componentsMap.get('service');
+		expect(services.length).toBe(2);
+		expect(new services[0].metatype()).toBeInstanceOf(TestService);
+		expect(new services[1].metatype()).toBeInstanceOf(TestService2);
+	});
+
+	it('should load multiple decorated and dynamic modules', async () => {
+		const componentsMap = await modulesLoader([MyModule, MyDynamicModule2], {});
+		const services = componentsMap.get('service');
+		expect(services.length).toBe(2);
+
+		/* Note: dynamic modules are always first to be added to ComponentMap */
+		expect(new services[0].metatype()).toBeInstanceOf(TestService2);
+		expect(new services[1].metatype()).toBeInstanceOf(TestService);
 	});
 });


### PR DESCRIPTION
**BUG**
when decorated and dynamic modules are loaded together presenting InjectableOptions with intersecting ComponentTypes - only entries from last one is used

issue occurs because when resolved InjectableOptions are assigned to existing ComponentMap there is no check for intersecting keys

**FIX**
I've added constructor to ComponentMap that does it

