### PR TITLE
adding test to reproduce bug. routes outside /admin do not have prope…

### DIFF
--- a/integration-tests/tests/fixtures/loaders.ts
+++ b/integration-tests/tests/fixtures/loaders.ts
@@ -51,6 +51,26 @@ export class CartService extends MedusaCartService {
 				},
 			],
 		},
+		{
+			path: '/admin/authenticated-all-test-middleware-path',
+			method: 'get',
+			requiredAuth: true,
+			handlers: [
+				(req: Request, res: Response, next: NextFunction) => {
+					return res.send(`${req.user.userId}`);
+				},
+			],
+		},
+		{
+			path: '/authenticated-all-test-middleware-path',
+			method: 'get',
+			requiredAuth: true,
+			handlers: [
+				(req: Request, res: Response, next: NextFunction) => {
+					return res.send(`${req.user.userId}`);
+				},
+			],
+		},
 	],
 })
 export class AdminRouter {}
@@ -101,6 +121,27 @@ AdminAuthTestPathMiddleware.prototype.consume = jest
 		next();
 	});
 
+@Middleware({
+	requireAuth: true,
+	routes: [
+		{
+			path: '*',
+			method: 'all',
+		}
+	],
+})
+export class AllAuthPathMiddleware implements MedusaMiddleware {
+	consume(req: MedusaRequest | Request, res: Response, next: NextFunction): void | Promise<void> {
+		return undefined;
+	}
+}
+AllAuthPathMiddleware.prototype.consume = jest
+	.fn()
+	.mockImplementation((req: MedusaRequest, res: Response, next: NextFunction) => {
+		expect(req.scope).toBeTruthy();
+		next();
+	});
+
 @Router({
 	routes: [
 		{
@@ -122,7 +163,7 @@ AdminAuthTestPathMiddleware.prototype.consume = jest
 					return res.send(`healthy ${req.params.test_id}`);
 				},
 			],
-		},
+		}
 	],
 })
 export class StoreRouter {}
@@ -210,6 +251,7 @@ CustomTopTestPathMiddleware.prototype.consume = jest
 		AdminRouter,
 		AdminTestPathMiddleware,
 		AdminAuthTestPathMiddleware,
+		AllAuthPathMiddleware,
 		StoreRouter,
 		StoreTestPathMiddleware,
 		CustomTopRouter,

--- a/integration-tests/tests/loaders.spec.ts
+++ b/integration-tests/tests/loaders.spec.ts
@@ -5,7 +5,7 @@ import { IdMap } from 'medusa-test-utils';
 import {
 	AdminAuthTestPathMiddleware,
 	AdminTestPathMiddleware,
-	CartService,
+	CartService, AllAuthPathMiddleware,
 	CustomTopTestPathMiddleware,
 	StoreTestPathMiddleware,
 	TestModule,
@@ -135,6 +135,39 @@ describe('Loaders', () => {
 			}).expect(200);
 			expect(AdminTestPathMiddleware.prototype.consume).not.toHaveBeenCalled();
 			expect(AdminAuthTestPathMiddleware.prototype.consume).toHaveBeenCalled();
+			expect(AllAuthPathMiddleware.prototype.consume).toHaveBeenCalled();
+		});
+
+		it('should apply authenticated middleware set for all routes (in /admin)', async () => {
+			const res = await makeRequest(context, {
+				path: `/admin/authenticated-all-test-middleware-path`,
+				method: 'get',
+				adminSession: {
+					jwt: {
+						userId: IdMap.getId('admin_user'),
+					},
+				},
+			}).expect(200);
+			expect(AdminTestPathMiddleware.prototype.consume).not.toHaveBeenCalled();
+			expect(AdminAuthTestPathMiddleware.prototype.consume).not.toHaveBeenCalled();
+			expect(AllAuthPathMiddleware.prototype.consume).toHaveBeenCalled();
+			expect(res.text).toBeTruthy();
+		});
+
+		it('should apply authenticated middleware set for all routes (not in /admin)', async () => {
+			const res = await makeRequest(context, {
+				path: `/authenticated-all-test-middleware-path`,
+				method: 'get',
+				adminSession: {
+					jwt: {
+						userId: IdMap.getId('admin_user'),
+					},
+				},
+			}).expect(200);
+			expect(AdminTestPathMiddleware.prototype.consume).not.toHaveBeenCalled();
+			expect(AdminAuthTestPathMiddleware.prototype.consume).not.toHaveBeenCalled();
+			expect(AllAuthPathMiddleware.prototype.consume).toHaveBeenCalled();
+			expect(res.text).toBeTruthy();
 		});
 	});
 


### PR DESCRIPTION
By running the tests, we can see that on the path request we don't have a 'user' property