### PR TITLE
fix(medusa-config): dont run all functions immediately in medusa-config, only promises

### DIFF
--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -52,7 +52,7 @@ export function attachOrReplaceEntitySubscriber<T extends Constructor<EntitySubs
  * @param keys
  * @constructor
  */
-export const Omit = <T, K extends keyof T>(Class: new () => T, keys: K[]): new () => Omit<T, (typeof keys)[number]> =>
+export const Omit = <T, K extends keyof T>(Class: new () => T, keys: K[]): new () => Omit<T, typeof keys[number]> =>
 	Class;
 
 /**

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -52,7 +52,7 @@ export function attachOrReplaceEntitySubscriber<T extends Constructor<EntitySubs
  * @param keys
  * @constructor
  */
-export const Omit = <T, K extends keyof T>(Class: new () => T, keys: K[]): new () => Omit<T, typeof keys[number]> =>
+export const Omit = <T, K extends keyof T>(Class: new () => T, keys: K[]): new () => Omit<T, (typeof keys)[number]> =>
 	Class;
 
 /**
@@ -84,7 +84,7 @@ export function buildRegexpIfValid(str: string): RegExp | undefined {
 }
 
 export const isPromise = (obj: unknown): boolean =>
-	!!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
+	!!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof (obj as any).then === 'function';
 
 export async function asyncLoadConfig(rootDir?: string, filename?: string): Promise<ConfigModule> {
 	const configuration = getConfigFile(rootDir ?? process.cwd(), filename ?? `medusa-config`) as {

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -83,6 +83,9 @@ export function buildRegexpIfValid(str: string): RegExp | undefined {
 	return;
 }
 
+export const isPromise = (obj: any): boolean =>
+	!!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
+
 export async function asyncLoadConfig(rootDir?: string, filename?: string): Promise<ConfigModule> {
 	const configuration = getConfigFile(rootDir ?? process.cwd(), filename ?? `medusa-config`) as {
 		configModule: ConfigModule;
@@ -93,8 +96,8 @@ export async function asyncLoadConfig(rootDir?: string, filename?: string): Prom
 			if (typeof obj[key] === 'object' && obj[key] !== null) {
 				await resolveConfigProperties(obj[key]);
 			}
-			if (typeof obj[key] === 'function') {
-				obj[key] = await obj[key]();
+			if (isPromise(obj[key])) {
+				obj[key] = await obj[key];
 			}
 		}
 		return obj;

--- a/src/core/utils.ts
+++ b/src/core/utils.ts
@@ -83,7 +83,7 @@ export function buildRegexpIfValid(str: string): RegExp | undefined {
 	return;
 }
 
-export const isPromise = (obj: any): boolean =>
+export const isPromise = (obj: unknown): boolean =>
 	!!obj && (typeof obj === 'object' || typeof obj === 'function') && typeof obj.then === 'function';
 
 export async function asyncLoadConfig(rootDir?: string, filename?: string): Promise<ConfigModule> {


### PR DESCRIPTION
The current way of running everything with `key[obj] === function` and setting the value is breaking plugins that require you to pass functions.

Now we only await promises, not all functions.