### PR TITLE
docs: fix loggedInUser declaration in middleware documentation

### DIFF
--- a/documentation/02-api-documentation.md
+++ b/documentation/02-api-documentation.md
@@ -331,7 +331,7 @@ export class LoggedInUserMiddleware implements MedusaMiddleware {
 		let loggedInUser = null;
 		if (req.user && req.user.userId) {
 			const userService = req.scope.resolve('userService') as UserService;
-			const loggedInUser = await userService.retrieve(req.user.userId, {
+			loggedInUser = await userService.retrieve(req.user.userId, {
 				select: ['id', 'your_custom_field'],
 			});
 		}


### PR DESCRIPTION
**Why**

In middleware docs `loggedInUser` is being declared twice and because of that value assigned in an `if` statement doesn't get updated.

**What**

Removed unnecessary `const`  
